### PR TITLE
Add delays between RPA actions

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import ttk, messagebox
 import threading
+import time
 
 
 class BankGUI(tk.Tk):
     """Banka işlemleri giriş arayüzü."""
+
+    # Bekleme süreleri (saniye)
+    WAIT_AFTER_CLICK = 0.5
+    WAIT_AFTER_TYPING = 0.2
+    WAIT_AFTER_SAVE = 1.0
 
     def __init__(self) -> None:
         super().__init__()
@@ -133,10 +139,19 @@ class BankGUI(tk.Tk):
     def add_transaction_via_popup(self, row: dict[str, str | float]) -> None:
         """RPA için popup üzerinden kayıt ekler."""
         self.open_form()
+        time.sleep(self.WAIT_AFTER_CLICK)
+
         self.entry_tarih.insert(0, str(row.get("Tarih", "")))
+        time.sleep(self.WAIT_AFTER_TYPING)
         self.entry_aciklama.insert(0, str(row.get("Açıklama", "")))
+        time.sleep(self.WAIT_AFTER_TYPING)
         self.entry_tutar.insert(0, str(row.get("Tutar", "")))
+        time.sleep(self.WAIT_AFTER_TYPING)
         self.entry_hesap.delete(0, tk.END)
         self.entry_hesap.insert(0, "6232011")
+        time.sleep(self.WAIT_AFTER_TYPING)
+
         self.kaydet()
+        time.sleep(self.WAIT_AFTER_SAVE)
+
         self.update()  # arayüzü güncelle

--- a/rpa_bot.py
+++ b/rpa_bot.py
@@ -14,6 +14,9 @@ from logger import RPALogger
 class RPABot:
     """Excel verilerini GUI'ye otomatik giren bot."""
 
+    # İşlemler arası bekleme süresi (saniye)
+    WAIT_BETWEEN_OPS = 0.8
+
     def __init__(self, gui_title: str = "Menü / Dashboard") -> None:
         self.gui_title = gui_title
         self.reader = DataReader()
@@ -61,8 +64,8 @@ class RPABot:
             self.logger.log_info(f"{idx}. satır işleniyor")
             try:
                 self.gui_window.add_transaction_via_popup(row)
-                time.sleep(0.1)
                 self.logger.log_success(row)
+                time.sleep(self.WAIT_BETWEEN_OPS)
             except Exception as exc:  # pragma: no cover - otomasyon hataları
                 self.logger.log_error(str(exc))
         self.logger.save_results()


### PR DESCRIPTION
## Summary
- slow down GUI automation by waiting after clicks, typing, saving and between transactions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python check_environment.py` *(fails waiting for input)*

------
https://chatgpt.com/codex/tasks/task_b_6883dca87ce8832f81f7294b64fe00b5