### PR TITLE
Add live commentary and slower RPA

### DIFF
--- a/rpa_bot.py
+++ b/rpa_bot.py
@@ -15,7 +15,7 @@ class RPABot:
     """Excel verilerini GUI'ye otomatik giren bot."""
 
     # İşlemler arası bekleme süresi (saniye)
-    WAIT_BETWEEN_OPS = 0.8
+    WAIT_BETWEEN_OPS = 1.6
 
     def __init__(self, gui_title: str = "Menü / Dashboard") -> None:
         self.gui_title = gui_title


### PR DESCRIPTION
## Summary
- slow down automation waits
- add a yellow live commentary box to the GUI
- switch account code field to a combobox with preset options
- show commentary while filling the popup

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6883de58d8bc832f99110342bbdfe59d