### PR TITLE
Add intermediate RPA bot and menu

### DIFF
--- a/02-Orta/create_complex_data.py
+++ b/02-Orta/create_complex_data.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from pathlib import Path
+
+
+def create_data(file_path: str = "../data/complex_data.xlsx") -> None:
+    """Karma\u015f\u0131k test verisi olu\u015fturur."""
+    data = [
+        {"Tarih": "01.08.2025", "Açıklama": "POSH GARANTİ MAGAZA/123456789012345", "Tutar": 1500.25},
+        {"Tarih": "01.08.2025", "Açıklama": "POSH XYZ/123456789012345", "Tutar": 500.0},
+        {"Tarih": "01.08.2025", "Açıklama": "POS SATIŞ YANLIŞ/12345", "Tutar": 100.0},
+        {"Tarih": "01.08.2025", "Açıklama": "POSH DENEME/000000000000000", "Tutar": 2000.0},
+        {"Tarih": "01.08.2025", "Açıklama": "DİĞER İŞLEM", "Tutar": 50.0},
+    ]
+    df = pd.DataFrame(data)
+    Path("../data").mkdir(exist_ok=True)
+    df.to_excel(file_path, index=False)
+    print(f"\u2705 Test verisi olusturuldu: {file_path} ({len(df)} kayit)")
+
+
+if __name__ == "__main__":
+    create_data()

--- a/02-Orta/data_reader.py
+++ b/02-Orta/data_reader.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from pathlib import Path
+
+
+class DataReader:
+    """Excel dosyasini okuyup regex filtresi uygulayan sinif."""
+
+    def __init__(self, file_path: str = "../data/complex_data.xlsx") -> None:
+        self.file_path = file_path
+        self.data: pd.DataFrame | None = None
+        self.pattern = r'^POSH.*\/\d{15}$'
+
+    def read_excel(self) -> bool:
+        try:
+            if not Path(self.file_path).exists():
+                raise FileNotFoundError(f"Excel dosyasi bulunamadi: {self.file_path}")
+            self.data = pd.read_excel(self.file_path)
+            print(f"\u2705 Excel okundu: {len(self.data)} satir")
+            return True
+        except Exception as exc:
+            print(f"\u274C Okuma hatasi: {exc}")
+            return False
+
+    def filter_by_pattern(self) -> list[dict[str, str | float]]:
+        if self.data is None:
+            return []
+        filtered = self.data[self.data['Açıklama'].astype(str).str.match(self.pattern, na=False)]
+        print(f"🔍 Pattern eslesmesi: {len(filtered)} kayit")
+        return filtered.to_dict("records")

--- a/02-Orta/main.py
+++ b/02-Orta/main.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from create_complex_data import create_data
+from rpa_bot import RPABot
+
+
+def main() -> None:
+    while True:
+        print("\n=== Orta Seviye RPA ===")
+        print("1) Test verisi oluştur")
+        print("2) RPA botunu çalıştır")
+        print("0) Çıkış")
+        choice = input("Seçiminiz: ").strip()
+        if choice == "1":
+            create_data()
+        elif choice == "2":
+            bot = RPABot()
+            bot.run()
+        elif choice == "0":
+            break
+        else:
+            print("Geçersiz seçim")
+
+
+if __name__ == "__main__":
+    main()

--- a/02-Orta/rpa_bot.py
+++ b/02-Orta/rpa_bot.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from data_reader import DataReader
+
+
+class RPABot:
+    """Conditional logic bot."""
+
+    def __init__(self) -> None:
+        self.reader = DataReader()
+
+    def run(self) -> None:
+        """Verileri oku ve kosullu isle."""
+        if not self.reader.read_excel():
+            return
+        records = self.reader.filter_by_pattern()
+        for rec in records:
+            desc = str(rec.get("Açıklama", ""))
+            amount = float(rec.get("Tutar", 0))
+            kategori = "Büyük İşlem" if amount > 1000 else "Normal"
+            banka = "Garanti" if "GARANTİ" in desc.upper() else "Diğer"
+            print(f"✅ {desc} | {amount:.2f} TL | {kategori} | Banka: {banka}")


### PR DESCRIPTION
## Summary
- add intermediate automation scripts under `02-Orta`
- generate complex sample data
- filter records by regex
- run bot with amount/bank logic
- provide simple menu

## Testing
- `python -m py_compile 02-Orta/data_reader.py 02-Orta/create_complex_data.py 02-Orta/rpa_bot.py 02-Orta/main.py`
- `pip install pandas --quiet`
- `pip install openpyxl --quiet`
- `python 02-Orta/create_complex_data.py`
- `python - <<'PY'
import sys
sys.path.insert(0, '02-Orta')
from rpa_bot import RPABot
bot = RPABot()
bot.run()
PY`

------
https://chatgpt.com/codex/tasks/task_b_688410b48304832f911c7f68811c572d