### PR TITLE
Focus GUI on startup

### DIFF
--- a/02-Orta/accounting_gui.py
+++ b/02-Orta/accounting_gui.py
@@ -12,6 +12,11 @@ class AdvancedAccountingGUI:
         self.root.geometry("1400x800")
         self.root.state('zoomed')  # Tam ekran başlat
 
+        # GUI'yi merkeze al ve öne getir
+        self.root.lift()
+        self.root.attributes('-topmost', True)
+        self.root.after(100, lambda: self.root.attributes('-topmost', False))
+
         self.data = pd.DataFrame()
         self.filtered_data = pd.DataFrame()
 

--- a/02-Orta/main.py
+++ b/02-Orta/main.py
@@ -55,8 +55,15 @@ def start_both() -> None:
 
     gui_app = AdvancedAccountingGUI()
 
-    # Start the bot shortly after the GUI opens so the window remains responsive
-    gui_app.root.after(100, start_bot_threaded)
+    # GUI'yi öne getir ve odakla
+    gui_app.root.lift()  # Pencereyi öne getir
+    gui_app.root.attributes('-topmost', True)  # En üstte tut
+    gui_app.root.after(100, lambda: gui_app.root.attributes('-topmost', False))  # 100ms sonra normal mod
+    gui_app.root.focus_force()  # Odağı zorla
+
+    # RPA'yı biraz gecikmeyle başlat ki GUI tam yüklensin
+    gui_app.root.after(2000, start_bot_threaded)  # 2 saniye sonra RPA başlat
+
     gui_app.run()
 
 


### PR DESCRIPTION
## Summary
- focus the GUI window and delay bot start
- keep the window on top briefly during initialization

## Testing
- `python -m py_compile 02-Orta/main.py 02-Orta/accounting_gui.py`

------
https://chatgpt.com/codex/tasks/task_b_6884d8e41884832fb05906d2f421093d