### PR TITLE
Fix missing GUI method call

### DIFF
--- a/02-Orta/accounting_gui.py
+++ b/02-Orta/accounting_gui.py
@@ -365,6 +365,26 @@ class AdvancedAccountingGUI:
     def export_records(self):
         """Kayıtları dışa aktar"""
         self.update_status("Dışa aktarma özelliği henüz geliştirilmemiş.")
+
+    def show_data(self):
+        """Yüklenen Excel verilerini göster"""
+        if not self.current_records:
+            messagebox.showinfo("Bilgi", "Gösterilecek veri bulunamadı.")
+            return
+
+        preview = tk.Toplevel(self.root)
+        preview.title("Yüklenen Veriler")
+
+        columns = list(self.current_records[0].keys())
+        tree = ttk.Treeview(preview, columns=columns, show="headings", height=15)
+        for col in columns:
+            tree.heading(col, text=col.title())
+            tree.column(col, width=150, anchor="w")
+        for rec in self.current_records:
+            tree.insert("", "end", values=[rec.get(col, "") for col in columns])
+        tree.pack(fill="both", expand=True, padx=10, pady=10)
+
+        ttk.Button(preview, text="Kapat", command=preview.destroy).pack(pady=5)
         
     def update_status(self, message):
         """Durum çubuğunu güncelle"""

--- a/02-Orta/rpa_bot.py
+++ b/02-Orta/rpa_bot.py
@@ -157,6 +157,17 @@ class AdvancedRPABot:
             if not self.load_excel_data():
                 self.log_step("❌ Veri yüklenemedi, işlem durduruluyor", 1)
                 return
+
+            # GUI'ye veriyi ata ve önizleme için göster
+            if self.gui is not None:
+                self.gui.current_records = list(self.excel_data)
+                print(f"DEBUG: GUI data assigned: {len(self.excel_data)} rows")
+                if hasattr(self.gui, "show_data"):
+                    print("DEBUG: Calling gui.show_data()...")
+                    try:
+                        self.gui.show_data()
+                    except Exception as exc:
+                        self.log_step(f"❌ GUI gosterim hatasi: {exc}", 1)
                 
             # 4. Her kayıt için döngü
             total_records = len(self.excel_data)


### PR DESCRIPTION
## Summary
- add `show_data` helper in `accounting_gui.py`
- preview loaded Excel data from `rpa_bot.run_automation_sequence`

## Testing
- `python -m py_compile 02-Orta/accounting_gui.py 02-Orta/rpa_bot.py`
- `python -m py_compile 02-Orta/main.py 02-Orta/data_reader.py`

------
https://chatgpt.com/codex/tasks/task_b_6884e3561468832fa351b64785e222f5