### PR TITLE
Add complex RPA example with Streamlit UI

### DIFF
--- a/03-Karmasik/advanced_gui.py
+++ b/03-Karmasik/advanced_gui.py
@@ -1,0 +1,81 @@
+import tkinter as tk
+from tkinter import ttk, messagebox, simpledialog
+
+class ComplexGUI:
+    """Karmaşık bir Tkinter arayüzü"""
+
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("Karmaşık Muhasebe Sistemi")
+        self.root.geometry("1200x700")
+        self.status_var = tk.StringVar(value="Hazır")
+        self._create_menus()
+        self._create_widgets()
+
+    def _create_menus(self) -> None:
+        menubar = tk.Menu(self.root)
+        self.root.config(menu=menubar)
+        menu_names = [
+            "Dosya", "Muhasebe", "Finans", "Raporlar",
+            "Ayarlar", "Yardım", "Ekstra"
+        ]
+        for name in menu_names:
+            menu = tk.Menu(menubar, tearoff=0)
+            menubar.add_cascade(label=name, menu=menu)
+            menu.add_command(
+                label=f"{name} Seçenek 1",
+                command=lambda n=name: self.menu_clicked(n)
+            )
+            menu.add_command(
+                label=f"{name} Seçenek 2",
+                command=lambda n=name: self.menu_clicked(n)
+            )
+
+    def _create_widgets(self) -> None:
+        self.progress = ttk.Progressbar(self.root, mode="determinate")
+        self.progress.pack(fill="x", pady=10, padx=10)
+        self.status_label = ttk.Label(self.root, textvariable=self.status_var)
+        self.status_label.pack(anchor="w", padx=10)
+        ttk.Button(
+            self.root,
+            text="İş Akışını Başlat",
+            command=self.start_flow
+        ).pack(pady=20)
+
+    def menu_clicked(self, name: str) -> None:
+        messagebox.showinfo("Menü", f"{name} menüsü seçildi")
+
+    def start_flow(self) -> None:
+        steps = [
+            "Giriş",
+            "Firma Seçimi",
+            "Modül Seçimi",
+            "Finans",
+            "Tahsilat",
+            "Veri Giriş",
+            "Onay"
+        ]
+        choice = simpledialog.askstring(
+            "Firma", "Firma adını girin", parent=self.root
+        )
+        if not choice:
+            messagebox.showwarning("Uyarı", "Firma seçilmedi")
+            return
+        for i, step in enumerate(steps, 1):
+            self.status_var.set(f"Adım {i}/{len(steps)}: {step}")
+            self.progress['value'] = i / len(steps) * 100
+            self.root.update()
+            self.root.after(300)
+            messagebox.showinfo("Adım", f"{step} adımı tamamlandı")
+        self.status_var.set("Akış tamamlandı")
+
+    def update_status(self, message: str) -> None:
+        self.status_var.set(message)
+        self.root.update_idletasks()
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+if __name__ == "__main__":
+    app = ComplexGUI()
+    app.run()

--- a/03-Karmasik/app.py
+++ b/03-Karmasik/app.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+from pathlib import Path
+
+from main import run_rpa_with_gui
+
+st.set_page_config(page_title="Karmaşık RPA", layout="centered")
+st.title("Karmaşık RPA Sistemi")
+
+uploaded_files = st.file_uploader(
+    "Excel dosyalarını sürükleyip bırakın",
+    type=["xlsx"],
+    accept_multiple_files=True,
+)
+
+start = st.button("Başla")
+progress_bar = st.progress(0.0)
+status = st.empty()
+
+if "results" not in st.session_state:
+    st.session_state["results"] = None
+
+if start:
+    if not uploaded_files:
+        st.warning("Lütfen önce dosya seçin")
+    else:
+        paths: list[Path] = []
+        save_dir = Path("uploaded")
+        save_dir.mkdir(exist_ok=True)
+        for uf in uploaded_files:
+            file_path = save_dir / uf.name
+            with open(file_path, "wb") as f:
+                f.write(uf.getbuffer())
+            paths.append(file_path)
+
+        def progress_callback(value: float, message: str) -> None:
+            progress_bar.progress(value)
+            status.text(message)
+
+        results = run_rpa_with_gui(paths, progress_callback)
+        st.session_state["results"] = results
+        status.text("Tüm dosyalar işlendi")
+        progress_bar.progress(1.0)
+
+if st.session_state.get("results"):
+    st.header("Sonuçlar")
+    df = pd.DataFrame(st.session_state["results"])
+    st.table(df)
+
+    if st.button("PDF Raporu Kaydet"):
+        from reportlab.lib.pagesizes import A4
+        from reportlab.pdfgen import canvas
+
+        pdf_path = Path("rapor.pdf")
+        c = canvas.Canvas(str(pdf_path), pagesize=A4)
+        c.drawString(100, 800, "RPA Sonuç Raporu")
+        y = 760
+        for row in st.session_state["results"]:
+            line = (
+                f"Dosya: {row['file']}  Kayıt: {row['records']}  Başarılı: {row['success']}"
+            )
+            c.drawString(80, y, line)
+            y -= 20
+        c.save()
+        st.success(f"PDF kaydedildi: {pdf_path}")

--- a/03-Karmasik/main.py
+++ b/03-Karmasik/main.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+import threading
+
+from advanced_gui import ComplexGUI
+from rpa_bot import EnterpriseRPABot
+
+
+def run_rpa_with_gui(excel_paths: list[Path], progress_callback=None):
+    gui = ComplexGUI()
+    bot = EnterpriseRPABot(gui)
+
+    def start_bot():
+        bot.run(excel_paths, progress_callback)
+        gui.update_status("RPA tamamlandı")
+
+    gui.root.after(1000, start_bot)
+    gui.run()
+    return bot.get_results()
+
+
+def start_gui_only() -> None:
+    app = ComplexGUI()
+    app.run()
+
+
+def start_both_default() -> None:
+    data_dir = Path("../Data")
+    files = list(data_dir.glob("*.xlsx"))
+    run_rpa_with_gui(files)
+
+
+def main() -> None:
+    while True:
+        print("\n" + "=" * 60)
+        print("KARMAŞIK RPA SİSTEMİ")
+        print("=" * 60)
+        print("1) Sadece GUI'yi başlat")
+        print("2) GUI + RPA başlat (Data klasöründeki tüm Excel'ler)")
+        print("0) Çıkış")
+        choice = input("Seçiminiz: ").strip()
+        if choice == "1":
+            start_gui_only()
+        elif choice == "2":
+            start_both_default()
+        elif choice == "0":
+            break
+        else:
+            print("Geçersiz seçim")
+
+
+if __name__ == "__main__":
+    main()

--- a/03-Karmasik/requirements.txt
+++ b/03-Karmasik/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+reportlab
+pandas

--- a/03-Karmasik/rpa_bot.py
+++ b/03-Karmasik/rpa_bot.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Callable, Iterable
+import pandas as pd
+
+class EnterpriseRPABot:
+    """Çoklu Excel dosyası işleyen basit RPA botu"""
+
+    def __init__(self, gui=None) -> None:
+        self.gui = gui
+        self.results: list[dict[str, int | str]] = []
+
+    def set_gui_reference(self, gui) -> None:
+        self.gui = gui
+
+    def _update_gui(self, message: str) -> None:
+        if self.gui and hasattr(self.gui, "update_status"):
+            self.gui.update_status(message)
+
+    def process_record(self, record: dict) -> None:
+        self._update_gui(f"Kayıt işleniyor: {record}")
+        time.sleep(0.1)  # Simülasyon
+
+    def process_excel(self, excel_path: Path) -> None:
+        try:
+            df = pd.read_excel(excel_path)
+            records = df.to_dict("records")
+        except Exception as exc:
+            self.results.append(
+                {"file": excel_path.name, "records": 0, "success": 0, "error": str(exc)}
+            )
+            return
+
+        total = len(records)
+        success = 0
+        for rec in records:
+            try:
+                self.process_record(rec)
+                success += 1
+            except Exception:
+                pass
+        self.results.append(
+            {"file": excel_path.name, "records": total, "success": success, "error": total - success}
+        )
+
+    def run(
+        self,
+        excel_files: Iterable[Path],
+        progress_callback: Callable[[float, str], None] | None = None,
+    ) -> None:
+        files = list(excel_files)
+        total = len(files)
+        for i, path in enumerate(files, 1):
+            if progress_callback:
+                progress_callback((i - 1) / total, f"Başlıyor: {path.name}")
+            self.process_excel(path)
+            if progress_callback:
+                progress_callback(i / total, f"Tamamlandı: {path.name}")
+        if progress_callback:
+            progress_callback(1.0, "Tüm dosyalar tamamlandı")
+
+    def get_results(self) -> list[dict[str, int | str]]:
+        return self.results


### PR DESCRIPTION
## Summary
- implement `ComplexGUI` with multi-step flow for manual navigation
- add `EnterpriseRPABot` that processes multiple Excel files sequentially
- provide `run_rpa_with_gui` helper and CLI in `03-Karmasik/main.py`
- create Streamlit frontend in `app.py` for drag&drop file upload, progress bar and PDF output
- document python dependencies

## Testing
- `python -m py_compile 03-Karmasik/*.py`


------
https://chatgpt.com/codex/tasks/task_b_6884ff705860832f8ef9146285149d9a