### PR TITLE
Keep data entry modal always on top

### DIFF
--- a/02-Orta/accounting_gui.py
+++ b/02-Orta/accounting_gui.py
@@ -270,7 +270,9 @@ class AdvancedAccountingGUI:
 
         self.data_entry_window.transient(self.root)
         self.data_entry_window.attributes('-topmost', True)
+        self.data_entry_window.attributes('-disabled', False)
         self.data_entry_window.lift()
+        self.data_entry_window.focus_force()
         # grab_set() kaldır - Dashboard'ı engellesin
 
         # Modal içeriği

--- a/03-Karmasik/advanced_gui.py
+++ b/03-Karmasik/advanced_gui.py
@@ -495,7 +495,9 @@ class EnterpriseGUI:
 
         self.data_entry_window.transient(self.root)
         self.data_entry_window.attributes('-topmost', True)
+        self.data_entry_window.attributes('-disabled', False)
         self.data_entry_window.lift()
+        self.data_entry_window.focus_force()
         # Modal değil - Dashboard'a erişim olsun
         
         # Modal içeriği

--- a/03-Karmasik/rpa_bot.py
+++ b/03-Karmasik/rpa_bot.py
@@ -109,6 +109,15 @@ class EnterpriseRPABot:
         except Exception:
             pass
 
+    def after_mouse_click(self):
+        """Mouse tıklamasından sonra modal'ı tekrar öne getir."""
+        if self.gui and getattr(self.gui, 'data_entry_window', None):
+            try:
+                self.gui.data_entry_window.lift()
+                self.gui.data_entry_window.focus_force()
+            except Exception:
+                pass
+
     class _BBoxWidget:
         """Notebook sekmeleri için sanal widget"""
 
@@ -181,6 +190,7 @@ class EnterpriseRPABot:
         # Tıklama gecikmesi
         time.sleep(random.uniform(0.1, 0.3) * self.delay_factor)
         self.log_step(f"✅ {widget_name} başarıyla tıklandı", delay)
+        self.call_in_gui_thread(self.after_mouse_click)
         
     # === PHASE 1: KARMAŞIK GUI NAVİGASYONU ===
     


### PR DESCRIPTION
## Summary
- ensure accounting and advanced data entry windows always stay topmost
- add helper in RPA bot to refocus modal after each simulated click
- refocus modal window after every click simulation

## Testing
- `python -m py_compile 02-Orta/accounting_gui.py 03-Karmasik/advanced_gui.py 03-Karmasik/rpa_bot.py`

------
https://chatgpt.com/codex/tasks/task_b_6885364e6528832fae0b4a1b979ad3ee