### PR TITLE
Fix widget text check

### DIFF
--- a/03-Karmasik/rpa_bot.py
+++ b/03-Karmasik/rpa_bot.py
@@ -589,9 +589,14 @@ class EnterpriseRPABot:
                 for widget in self.gui.data_entry_window.winfo_children():
                     if hasattr(widget, 'winfo_children'):
                         for child in widget.winfo_children():
-                            if hasattr(child, 'cget') and 'Kaydet' in str(child.cget('text')):
-                                save_button = child
-                                break
+                            if hasattr(child, 'cget'):
+                                try:
+                                    text_val = child.cget('text')
+                                except tk.TclError:
+                                    continue
+                                if 'Kaydet' in str(text_val):
+                                    save_button = child
+                                    break
 
             if save_button:
                 self.click_widget_simulation("Kaydet butonu", save_button, delay=0.5)


### PR DESCRIPTION
## Summary
- avoid TclError when reading button text in advanced GUI bot

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68855679f834832fbf7d4aad3bcf8796