### PR TITLE
Fix RPA step confirmation wait

### DIFF
--- a/03-Karmasik/rpa_bot.py
+++ b/03-Karmasik/rpa_bot.py
@@ -96,7 +96,8 @@ class EnterpriseRPABot:
         try:
             self.gui.root.winfo_exists()
             self.gui.root.after(0, wrapper)
-            done.wait(timeout=5.0)
+            # Adım içi onay gerektiren pop-up'lar için süre sınırı olmadan bekle
+            done.wait()
         except tk.TclError:
             self.log_step("⚠️ Ana pencere mevcut değil", 0.1)
             return None


### PR DESCRIPTION
## Summary
- make the GUI helper `call_in_gui_thread` wait indefinitely so user confirmation is required

## Testing
- `python -m py_compile 03-Karmasik/rpa_bot.py`

------
https://chatgpt.com/codex/tasks/task_b_6885599db604832fb73ff86cc621429d