### PR TITLE
Fix call_in_gui_thread timeout removal

### DIFF
--- a/02-Orta/rpa_bot.py
+++ b/02-Orta/rpa_bot.py
@@ -26,7 +26,7 @@ class AdvancedRPABot:
             self.gui.update_status(f"RPA: {message}")
         time.sleep(delay)
 
-    def call_in_gui_thread(self, func, *args, timeout=None, **kwargs):
+    def call_in_gui_thread(self, func, *args, **kwargs):
         """Tkinter ana döngüsünde fonksiyon çalıştır"""
         if not self.gui:
             return
@@ -39,7 +39,7 @@ class AdvancedRPABot:
                 done.set()
 
         self.gui.root.after(0, wrapper)
-        done.wait(timeout)
+        done.wait()
         
     def click_simulation(self, widget_name, delay=0.5):
         """Widget tıklama simülasyonu"""


### PR DESCRIPTION
## Summary
- remove `timeout` parameter from `call_in_gui_thread`
- update call site to use `done.wait()`

## Testing
- `python -m py_compile 02-Orta/rpa_bot.py`


------
https://chatgpt.com/codex/tasks/task_b_6886470c0bdc832fb8c75b6c83355a5a