### PR TITLE
Ensure data entry window stays visible

### DIFF
--- a/03-Karmasik/gui/base_gui.py
+++ b/03-Karmasik/gui/base_gui.py
@@ -1139,6 +1139,8 @@ class Level3EnterpriseGUI:
             # Modal properties
             self.data_entry_window.transient(self.root)
             self.data_entry_window.attributes('-alpha', 0.95)  # Slight transparency
+            # Keep modal always on top so it doesn't disappear during RPA
+            self.data_entry_window.attributes('-topmost', True)
             self.data_entry_window.lift()
             self.data_entry_window.focus_set()
 

--- a/03-Karmasik/rpa/core_engine.py
+++ b/03-Karmasik/rpa/core_engine.py
@@ -147,6 +147,8 @@ class EnterpriseRPABot:
         if self.gui and getattr(self.gui, 'data_entry_window', None):
             try:
                 self.gui.data_entry_window.lift()
+                # Ensure modal stays on top during automation
+                self.gui.data_entry_window.attributes('-topmost', True)
                 self.gui.data_entry_window.focus_force()
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- keep the data entry modal always on top so it doesn't vanish during automation
- enforce topmost attribute whenever mouse clicks are simulated

## Testing
- `python -m py_compile 03-Karmasik/gui/base_gui.py 03-Karmasik/rpa/core_engine.py`

------
https://chatgpt.com/codex/tasks/task_b_6886532bc14c832f9ea779ec28e4f25b