### PR TITLE
Add alternate mouse-driven RPA start

### DIFF
--- a/04-Notepad++/images/README.md
+++ b/04-Notepad++/images/README.md
@@ -1,0 +1,5 @@
+# Image Templates
+
+Bu klasör, Notepad++ menü ve butonları için ekran görüntüsü şablonlarını içerir.
+RPA "mouse" modu `file_menu.png`, `new_file.png`, `save_file.png` ve `close_button.png`
+isimli dosyaları burada arar.

--- a/04-Notepad++/notepad_app.py
+++ b/04-Notepad++/notepad_app.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from pathlib import Path
 from notepad_automation import NotepadPPAutomation
 
 try:
@@ -7,30 +6,64 @@ try:
 except Exception:  # pragma: no cover - library might not be installed in tests
     docx = None
 
+
+def _read_uploaded_text(file):
+    """Return text content of uploaded file."""
+    file.seek(0)
+    if file.name.endswith(".txt"):
+        return file.read().decode("utf-8")
+    if docx is None:
+        st.error("docx desteği bulunamadı")
+        st.stop()
+    document = docx.Document(file)
+    return "\n".join(p.text for p in document.paragraphs)
+
+
 st.title("📝 Notepad++ RPA")
 
 uploaded_file = st.file_uploader(
     "Bir .txt veya .docx dosyası yükleyin", type=["txt", "docx"]
 )
 
-if st.button("RPA'yı Başlat"):
+col1, col2 = st.columns(2)
+with col1:
+    start_hotkey = st.button("🚀 RPA Başlat", key="start_rpa_kb")
+with col2:
+    start_mouse = st.button("🖱️ RPA Başlat - 2", key="start_rpa_mouse")
+
+st.markdown(
+    """
+    <style>
+    div[id="start_rpa_kb"] button {
+        background-color: #4CAF50;
+        color: white;
+    }
+    div[id="start_rpa_mouse"] button {
+        background-color: #FF5722;
+        color: white;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+if start_hotkey or start_mouse:
     if not uploaded_file:
         st.error("Lütfen önce bir dosya yükleyin.")
     else:
-        if uploaded_file.name.endswith(".txt"):
-            text = uploaded_file.read().decode("utf-8")
-        else:
-            if docx is None:
-                st.error("docx desteği bulunamadı")
-                st.stop()
-            document = docx.Document(uploaded_file)
-            text = "\n".join(p.text for p in document.paragraphs)
-
+        text = _read_uploaded_text(uploaded_file)
         bot = NotepadPPAutomation()
         bot.launch()
-        bot.new_file()
+        if start_hotkey:
+            bot.new_file()
+        else:
+            bot.new_file_mouse()
         bot.write_text(text)
         save_path = r"D:\\Mira\\Mira.py"
-        bot.save_file(save_path)
-        bot.close()
+        if start_hotkey:
+            bot.save_file(save_path)
+            bot.close()
+        else:
+            bot.save_file_mouse(save_path)
+            bot.close_mouse()
         st.success(f"Metin Notepad++ ile kaydedildi: {save_path}")

--- a/04-Notepad++/notepad_automation.py
+++ b/04-Notepad++/notepad_automation.py
@@ -44,6 +44,39 @@ class NotepadPPAutomation:
         pyautogui.hotkey("alt", "f4")
         time.sleep(0.5)
 
+    # --- Mouse based interactions ---------------------------------
+    def new_file_mouse(self, image_dir: str = "images") -> None:
+        """Open a new file by clicking menu items instead of using hotkeys.
+
+        Parameters
+        ----------
+        image_dir: str
+            Directory containing the screenshot templates like
+            ``file_menu.png`` and ``new_file.png`` used for visual search.
+        """
+        self.click_menu(Path(image_dir) / "file_menu.png")
+        time.sleep(0.2)
+        self.click_menu(Path(image_dir) / "new_file.png")
+        time.sleep(0.2)
+
+    def save_file_mouse(self, path: str, image_dir: str = "images") -> None:
+        """Save the current document using mouse clicks.
+
+        This method avoids keyboard shortcuts by opening the *File* menu and
+        clicking the *Save* option through template matching.
+        """
+        self.click_menu(Path(image_dir) / "file_menu.png")
+        time.sleep(0.2)
+        self.click_menu(Path(image_dir) / "save_file.png")
+        time.sleep(0.5)
+        pyautogui.typewrite(path)
+        pyautogui.press("enter")
+
+    def close_mouse(self, image_dir: str = "images") -> None:
+        """Close Notepad++ by clicking the window close button."""
+        self.click_menu(Path(image_dir) / "close_button.png")
+        time.sleep(0.5)
+
     def click_menu(self, image_path: str, confidence: float = 0.8) -> bool:
         """Click a menu or button identified by an image template."""
         location = locate_on_screen(image_path, confidence)


### PR DESCRIPTION
## Summary
- Add menu-driven automation methods in `NotepadPPAutomation`
- Extend Streamlit demo with two colored RPA start buttons and mouse-based mode
- Document required screenshot templates for mouse-click automation

## Testing
- `python -m py_compile 04-Notepad++/notepad_automation.py 04-Notepad++/notepad_app.py`


------
https://chatgpt.com/codex/tasks/task_b_689112062324832f84bab2f23a6e66e9