### PR TITLE
Add Notepad++ automation details and path

### DIFF
--- a/04-Notepad++/main.py
+++ b/04-Notepad++/main.py
@@ -105,9 +105,10 @@ def start_rpa_only() -> None:
 def start_notepad_demo() -> None:
     """Basit Notepad++ otomasyon demoesi."""
     print("📝 Notepad++ otomasyonu başlatılıyor...")
-    from notepad_automation import NotepadPPAutomation
+    from notepad_automation import NotepadPPAutomation, NOTEPAD_PATH
 
-    bot = NotepadPPAutomation()
+    notepad_path = NOTEPAD_PATH
+    bot = NotepadPPAutomation(executable=notepad_path)
     bot.launch()
     bot.write_text("Merhaba Notepad++!\nBu bir RPA demosudur.")
     bot.save_file("notepad_demo.txt")

--- a/04-Notepad++/notepad_automation.py
+++ b/04-Notepad++/notepad_automation.py
@@ -12,6 +12,10 @@ from ocr_utils import ocr_screen
 from vision_utils import locate_on_screen
 
 
+# Windows sistemlerde Notepad++ uygulamasının varsayılan kurulum yolu.
+NOTEPAD_PATH = r"D:\\Program Files\\Notepad++\\notepad++.exe"
+
+
 class NotepadPPAutomation:
     """Simple helper for automating Notepad++ actions."""
 
@@ -25,7 +29,7 @@ class NotepadPPAutomation:
 
     def __init__(
         self,
-        executable: str = "notepad++",
+        executable: str = NOTEPAD_PATH,
         templates: Optional[Dict[str, str]] = None,
     ) -> None:
         self.executable = executable

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # 🤖 RPA Örnekleri
 
-Bu repoda, Robotic Process Automation konseptini kademeli olarak öğreten üç ayrı proje yer alır. Her klasör bir öncekini temel alarak daha gelişmiş örnekler içerir.
+Bu repoda, Robotic Process Automation konseptini kademeli olarak öğreten dört ayrı proje yer alır. Her klasör bir öncekini temel alarak daha gelişmiş örnekler içerir.
 
 ## Klasörler
 
 - **01-Basit/** – Excel verilerini Tkinter tabanlı basit bir forma otomatik girmek için hazırlanmış ilk öğrenme projesi.
 - **02-Orta/** – "Muhasebe Pro" tarzı çok sekmeli ve araç çubuklu gelişmiş GUI. Excel yükledikten sonra kayıtları regex, tutar veya tarih filtreleriyle inceleme imkânı sunar.
 - **03-Karmasik/** – Çoklu Excel dosyası işleyebilen, detaylı Tkinter arayüzüne ve Streamlit tabanlı web paneline sahip enterprise seviye bir sistem.
+- **04-Notepad++/** – PyAutoGUI, OCR ve görsel eşleştirme kullanarak Notepad++ üzerinde metin oluşturma ve kaydetme otomasyonu yapar.
 - **Data/** – Örnek Excel dosyalarını koyabileceğiniz klasör. Betikler `../Data` yolunu kullanır.
 
 ## Hızlı Başlangıç
@@ -37,10 +38,18 @@ streamlit run app.py      # Web paneli
 
 Kompleks sistemde GUI + RPA bütünleşik şekilde demo modunda çalıştırılabilir ve Streamlit paneli üzerinden sürükle‑bırak yöntemiyle Excel dosyaları yüklenebilir.
 
+### 04-Notepad++
+```bash
+cd 04-Notepad++
+python main.py
+```
+Menüden `7` seçeneğini kullanarak Notepad++ otomasyon demosunu çalıştırabilirsiniz.
+
 ## Gereksinimler
 
 - `01-Basit/requirements.txt` temel paketleri içerir (pandas, openpyxl, pyautogui ...).
 - `03-Karmasik/requirements.txt` ek olarak `streamlit` ve `reportlab` gibi kütüphaneler gerektirir.
+- `04-Notepad++/requirements.txt` PyAutoGUI, Tesseract OCR ve OpenCV gibi ek bağımlılıklar içerir.
 
 ## Lisans
 


### PR DESCRIPTION
## Summary
- Document new `04-Notepad++` project in root README with quick-start instructions and requirements
- Provide default Windows installation path for Notepad++ automation and use it in demo launcher

## Testing
- `python -m py_compile 04-Notepad++/main.py 04-Notepad++/notepad_automation.py`


------
https://chatgpt.com/codex/tasks/task_b_6892096fe018832fb4f66cca1a9b6e5e