### PR TITLE
Fix Notepad++ demo automation

### DIFF
--- a/04-Notepad++/main.py
+++ b/04-Notepad++/main.py
@@ -110,8 +110,10 @@ def start_notepad_demo() -> None:
     notepad_path = NOTEPAD_PATH
     bot = NotepadPPAutomation(executable=notepad_path)
     bot.launch()
+    bot.new_file()
     bot.write_text("Merhaba Notepad++!\nBu bir RPA demosudur.")
     bot.save_file("notepad_demo.txt")
+    bot.close()
     print("✅ Notepad++ otomasyonu tamamlandı")
 
 

--- a/04-Notepad++/notepad_automation.py
+++ b/04-Notepad++/notepad_automation.py
@@ -40,6 +40,12 @@ class NotepadPPAutomation:
         """Launch Notepad++ application."""
         subprocess.Popen([self.executable])
         time.sleep(2)  # wait for the window to appear
+        # Bring the application window to the foreground so that
+        # subsequent keyboard commands target Notepad++.
+        windows = pyautogui.getWindowsWithTitle("Notepad++")
+        if windows:
+            windows[0].activate()
+            time.sleep(0.2)
 
     def new_file(self) -> None:
         """Open a new blank document in Notepad++."""
@@ -51,11 +57,17 @@ class NotepadPPAutomation:
         pyautogui.typewrite(text, interval=interval)
 
     def save_file(self, path: str) -> None:
-        """Save the current document to the given path."""
-        pyautogui.hotkey("ctrl", "s")
+        """Save the current document to the given path.
+
+        ``Ctrl+Shift+S`` is used to always trigger the *Save As* dialog
+        even if the document already has a filename. This prevents
+        accidental typing into the editor when no dialog appears.
+        """
+        pyautogui.hotkey("ctrl", "shift", "s")
         time.sleep(0.5)
         pyautogui.typewrite(path)
         pyautogui.press("enter")
+        time.sleep(0.5)
 
     def close(self) -> None:
         """Close the active Notepad++ window."""


### PR DESCRIPTION
## Summary
- Activate Notepad++ window after launching and use Ctrl+Shift+S to reliably open the Save As dialog.
- Demo function now opens a new file, writes sample text, saves, and closes Notepad++.

## Testing
- `python -m py_compile 04-Notepad++/notepad_automation.py 04-Notepad++/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68920ce5a140832f9c85aa1c62a9c0c7