### PR TITLE
Improve Notepad++ RPA focus handling

### DIFF
--- a/04-Notepad++/notepad_automation.py
+++ b/04-Notepad++/notepad_automation.py
@@ -36,16 +36,35 @@ class NotepadPPAutomation:
         # Allow overriding of template filenames
         self.templates = {**self.DEFAULT_TEMPLATES, **(templates or {})}
 
-    def launch(self) -> None:
-        """Launch Notepad++ application."""
-        subprocess.Popen([self.executable])
-        time.sleep(2)  # wait for the window to appear
-        # Bring the application window to the foreground so that
-        # subsequent keyboard commands target Notepad++.
+    def _focus_editor(self) -> None:
+        """Ensure the main editor window is focused.
+
+        This helper activates the Notepad++ window, closes any stray
+        dialogs such as the *Find* panel with ``ESC`` and finally clicks
+        inside the editor area so that subsequent keyboard input is
+        directed to the correct location.
+        """
         windows = pyautogui.getWindowsWithTitle("Notepad++")
-        if windows:
-            windows[0].activate()
-            time.sleep(0.2)
+        if not windows:
+            return
+        win = windows[0]
+        win.activate()
+        # give the OS some time to bring the window to the foreground
+        time.sleep(0.5)
+        # close any pop-ups like the "Find" dialog
+        pyautogui.press("esc")
+        # click roughly in the centre of the window to focus the editor
+        center_x = win.left + win.width // 2
+        center_y = win.top + win.height // 2
+        pyautogui.click(center_x, center_y)
+        time.sleep(0.2)
+
+    def launch(self) -> None:
+        """Launch Notepad++ application and focus the editor."""
+        subprocess.Popen([self.executable])
+        # wait for the window to appear before attempting to focus
+        time.sleep(2)
+        self._focus_editor()
 
     def new_file(self) -> None:
         """Open a new blank document in Notepad++."""
@@ -53,7 +72,14 @@ class NotepadPPAutomation:
         time.sleep(0.2)
 
     def write_text(self, text: str, interval: float = 0.05) -> None:
-        """Type text into the active Notepad++ window."""
+        """Type text into the active Notepad++ editor.
+
+        Before typing we explicitly focus the editor area to prevent the
+        keystrokes from going into auxiliary dialogs such as the *Find*
+        box. A short delay is added after focusing to ensure the window is
+        ready to receive input.
+        """
+        self._focus_editor()
         pyautogui.typewrite(text, interval=interval)
 
     def save_file(self, path: str) -> None:
@@ -75,7 +101,7 @@ class NotepadPPAutomation:
         time.sleep(0.5)
 
     # --- Mouse based interactions ---------------------------------
-    def new_file_mouse(self, image_dir: str = "images") -> None:
+    def new_file_mouse(self, image_dir: str = "images", confidence: float = 0.9) -> None:
         """Open a new file by clicking menu items instead of using hotkeys.
 
         Parameters
@@ -84,37 +110,66 @@ class NotepadPPAutomation:
             Directory containing screenshot templates. By default the
             automation expects sequentially named files such as ``1.jpg``
             (File menu) and ``2.jpg`` (New file).
+        confidence: float, optional
+            Image match confidence forwarded to :meth:`click_menu`.
         """
         file_menu = Path(image_dir) / self.templates["file_menu"]
         new_file = Path(image_dir) / self.templates["new_file"]
-        self.click_menu(file_menu)
+        self.click_menu(file_menu, confidence)
         time.sleep(0.2)
-        self.click_menu(new_file)
+        self.click_menu(new_file, confidence)
         time.sleep(0.2)
 
-    def save_file_mouse(self, path: str, image_dir: str = "images") -> None:
+    def save_file_mouse(self, path: str, image_dir: str = "images", confidence: float = 0.9) -> None:
         """Save the current document using mouse clicks.
 
         This method avoids keyboard shortcuts by opening the *File* menu and
         clicking the *Save* option through template matching.
+
+        Parameters
+        ----------
+        path: str
+            File path to save to.
+        image_dir: str
+            Directory containing screenshot templates.
+        confidence: float, optional
+            Image match confidence forwarded to :meth:`click_menu`.
         """
         file_menu = Path(image_dir) / self.templates["file_menu"]
         save_file = Path(image_dir) / self.templates["save_file"]
-        self.click_menu(file_menu)
+        self.click_menu(file_menu, confidence)
         time.sleep(0.2)
-        self.click_menu(save_file)
+        self.click_menu(save_file, confidence)
         time.sleep(0.5)
         pyautogui.typewrite(path)
         pyautogui.press("enter")
 
-    def close_mouse(self, image_dir: str = "images") -> None:
-        """Close Notepad++ by clicking the window close button."""
+    def close_mouse(self, image_dir: str = "images", confidence: float = 0.9) -> None:
+        """Close Notepad++ by clicking the window close button.
+
+        Parameters
+        ----------
+        image_dir: str
+            Directory containing screenshot templates.
+        confidence: float, optional
+            Image match confidence forwarded to :meth:`click_menu`.
+        """
         close_button = Path(image_dir) / self.templates["close_button"]
-        self.click_menu(close_button)
+        self.click_menu(close_button, confidence)
         time.sleep(0.5)
 
-    def click_menu(self, image_path: str, confidence: float = 0.8) -> bool:
-        """Click a menu or button identified by an image template."""
+    def click_menu(self, image_path: str, confidence: float = 0.9) -> bool:
+        """Click a menu or button identified by an image template.
+
+        Parameters
+        ----------
+        image_path: str
+            Path to the screenshot template to match.
+        confidence: float, optional
+            Matching threshold used by image recognition. Increasing the
+            value can reduce false positives when screen colours or
+            resolutions differ.
+        """
         location = locate_on_screen(image_path, confidence)
         if location:
             x, y = location


### PR DESCRIPTION
## Summary
- ensure Notepad++ editor is focused before typing by activating window, closing Find dialog and clicking editor
- call this focus step on launch and prior to typing, preventing text from going to the Find box
- expose confidence parameter for mouse-based actions and tighten default image match threshold

## Testing
- `pytest`
- `python -m py_compile 04-Notepad++/notepad_automation.py`


------
https://chatgpt.com/codex/tasks/task_b_689222578cac832f885dba37976dd938