### PR TITLE
Ensure mouse-based Notepad++ RPA start closes search panel

### DIFF
--- a/04-Notepad++/notepad_automation.py
+++ b/04-Notepad++/notepad_automation.py
@@ -131,6 +131,10 @@ class NotepadPPAutomation:
         confidence: float, optional
             Image match confidence forwarded to :meth:`click_menu`.
         """
+        # Ensure editor window is active and close any pop-ups like the
+        # advanced search panel before using image-based clicks.
+        self._focus_editor()
+
         file_menu = Path(image_dir) / self.templates["file_menu"]
         new_file = Path(image_dir) / self.templates["new_file"]
         self.click_menu(file_menu, confidence)


### PR DESCRIPTION
## Summary
- Focus the Notepad++ editor before mouse-driven `RPA Başlat - 2` workflow to close stray dialogs and prevent Advanced Search from appearing.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689238ebb878832f99d469bf2b3c7a80