### PR TITLE
Ensure mouse-based Notepad++ RPA start closes search panel

### DIFF
--- a/04-Notepad++/notepad_automation.py
+++ b/04-Notepad++/notepad_automation.py
@@ -131,6 +131,10 @@ class NotepadPPAutomation:
         confidence: float, optional
             Image match confidence forwarded to :meth:`click_menu`.
         """
+        # Ensure editor window is active and close any pop-ups like the
+        # advanced search panel before using image-based clicks.
+        self._focus_editor()
+
         file_menu = Path(image_dir) / self.templates["file_menu"]
         new_file = Path(image_dir) / self.templates["new_file"]
         self.click_menu(file_menu, confidence)
@@ -153,6 +157,11 @@ class NotepadPPAutomation:
         confidence: float, optional
             Image match confidence forwarded to :meth:`click_menu`.
         """
+        # Ensure the main window is active and dismiss any dialogs like the
+        # advanced search panel which might steal subsequent clicks or
+        # keystrokes.
+        self._focus_editor()
+
         file_menu = Path(image_dir) / self.templates["file_menu"]
         save_file = Path(image_dir) / self.templates["save_file"]
         self.click_menu(file_menu, confidence)
@@ -172,6 +181,10 @@ class NotepadPPAutomation:
         confidence: float, optional
             Image match confidence forwarded to :meth:`click_menu`.
         """
+        # Bring the Notepad++ window to the foreground and close any stray
+        # pop-ups before attempting to click the close button.
+        self._focus_editor()
+
         close_button = Path(image_dir) / self.templates["close_button"]
         self.click_menu(close_button, confidence)
         time.sleep(0.5)


### PR DESCRIPTION
## Summary
- Ensure editor is focused before mouse-driven save and close operations to avoid stray dialogs like Advanced Search.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689238ebb878832f99d469bf2b3c7a80